### PR TITLE
Add support for rendering external image links and YouTube videos

### DIFF
--- a/site/src/app/elements/ActivityPost.tsx
+++ b/site/src/app/elements/ActivityPost.tsx
@@ -20,6 +20,7 @@ import { AO_STORY, AO_TWITTER, STORY_INCOME } from '../util/consts';
 import MessageModal from '../modals/MessageModal';
 import BountyRecordsModal from '../modals/BountyRecordsModal';
 import { HiOutlineLockClosed } from "react-icons/hi2";
+import ExternalEmbed from './externalEmbed';
 
 interface ActivityPostProps {
   data: any;
@@ -56,6 +57,10 @@ class ActivityPost extends React.Component<ActivityPostProps, ActivityPostState>
       if (domNode.attribs && domNode.name === 'img') {
         const props = attributesToProps(domNode.attribs);
         return <img className='ql-editor-image' onClick={(e) => this.tapImage(e, props.src)} {...props} />;
+      } else if (domNode.name === 'span' && domNode.attribs) {
+        if (domNode.attribs.class === 'youtube-url') {
+          return <ExternalEmbed src={domNode.attribs['data-src']} />;
+        }
       }
     }
   };

--- a/site/src/app/elements/NotiCard.tsx
+++ b/site/src/app/elements/NotiCard.tsx
@@ -10,6 +10,7 @@ import { Service } from '../../server/service';
 import { subscribe } from '../util/event';
 import { Tooltip } from 'react-tooltip'
 import MessageModal from '../modals/MessageModal';
+import ExternalEmbed from './externalEmbed';
 
 interface NotiCardProps {
   data: any;
@@ -36,6 +37,10 @@ class NotiCard extends React.Component<NotiCardProps, NotiCardState> {
       if (domNode.attribs && domNode.name === 'img') {
         const props = attributesToProps(domNode.attribs);
         return <img className='ql-editor-image' onClick={(e) => this.tapImage(e, props.src)} {...props} />;
+      } else if (domNode.name === 'span' && domNode.attribs) {
+        if (domNode.attribs.class === 'youtube-url') {
+          return <ExternalEmbed src={domNode.attribs['data-src']} />;
+        }
       }
     }
   };

--- a/site/src/app/elements/externalEmbed.css
+++ b/site/src/app/elements/externalEmbed.css
@@ -1,0 +1,16 @@
+.embed-container {
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio */
+  width: 100%;
+  height: 0;
+}
+
+.embed-container iframe.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}

--- a/site/src/app/elements/externalEmbed.tsx
+++ b/site/src/app/elements/externalEmbed.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import './externalEmbed.css';
+import { regexPatterns } from '../util/consts';
+
+interface ExternalEmbedProps {
+    src: string;
+}
+
+const ExternalEmbed: React.FC<ExternalEmbedProps> = ({ src }) => {
+    const { youtubeRegex } = regexPatterns;
+    // console.log('ExternalEmbed:', src);
+    const getVideoID = (src: string): string | null => {
+        const match = src.match(youtubeRegex);
+        return match ? match[1] : null;
+      };
+    
+      const videoId = getVideoID(src);
+    
+      if (!videoId) {
+        return <p>Invalid video URL: ${src}</p>;
+      }
+    
+      const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+      const iframeTitle = `YouTube video player`;
+
+    return (
+        <div className="embed-container">
+            <iframe
+                className="responsive-iframe"
+                src={embedUrl}
+                title={iframeTitle}
+                frameBorder="0"
+                allowFullScreen
+            ></iframe>
+        </div>
+    );
+};
+
+export default ExternalEmbed;

--- a/site/src/app/util/consts.ts
+++ b/site/src/app/util/consts.ts
@@ -1,3 +1,10 @@
+export const regexPatterns = {
+  urlRegex: /(\b(https?:\/\/|www\.)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig,
+  imageRegex: /\.(jpeg|jpg|gif|png|svg)$/i,
+  hrefRegex: /<a\s+[^>]*?href\s*=\s*(['"])(.*?)\1/g,
+  youtubeRegex: /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+};
+
 // export const AO_TWITTER = "Y4ZXUT9jFoHFg3K2XH5MVFf4_mXKHAcCsqgLta1au2U";
 // export const AO_TWITTER = "Ekm_mCHSs9mawVqwqTi35qBaT-8DaORzYJ-c9Z3qMhY";
 // export const AO_STORY = "Ur_5hhtX6zQEpFg9jPzFULMTLRvkBfp4bn7Od4Qj4Jk";

--- a/site/src/app/util/util.ts
+++ b/site/src/app/util/util.ts
@@ -185,6 +185,7 @@ export function convertHashTag(str: string): any {
  */
 export function convertUrlsToLinks(text: string) {
   const urlRegex = /(\b(https?:\/\/|www\.)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+  const imageRegex = /\.(jpeg|jpg|gif|png|svg)$/i;
 
   // match all of <a> tag content
   const hrefRegex = /<a\s+[^>]*?href\s*=\s*(['"])(.*?)\1/g;
@@ -194,6 +195,8 @@ export function convertUrlsToLinks(text: string) {
   const convertedText = text.replace(urlRegex, (url) => {
     if (hrefs && hrefs.includes(`<a href="${url}"`))
       return url;
+    else if (imageRegex.test(url))
+      return `<img src="${url}" alt="${url}" class="ql-editor-image"/>`;
     else
       return `<a href=${url} target="_blank" id="url-${url}">${url}</a>`;
   });

--- a/site/src/app/util/util.ts
+++ b/site/src/app/util/util.ts
@@ -1,5 +1,5 @@
 import { createDataItemSigner, dryrun, message, spawn } from "@permaweb/aoconnect/browser";
-import { AO_TWITTER, ARWEAVE_GATEWAY, MODULE, SCHEDULER } from "./consts";
+import { AO_TWITTER, ARWEAVE_GATEWAY, MODULE, SCHEDULER, regexPatterns } from "./consts";
 import { Server } from "../../server/server";
 import { createAvatar } from '@dicebear/core';
 import { micah } from '@dicebear/collection';
@@ -184,17 +184,17 @@ export function convertHashTag(str: string): any {
  * @returns 
  */
 export function convertUrlsToLinks(text: string) {
-  const urlRegex = /(\b(https?:\/\/|www\.)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
-  const imageRegex = /\.(jpeg|jpg|gif|png|svg)$/i;
+  const { urlRegex, imageRegex, hrefRegex, youtubeRegex } = regexPatterns;
 
   // match all of <a> tag content
-  const hrefRegex = /<a\s+[^>]*?href\s*=\s*(['"])(.*?)\1/g;
   const hrefs = text.match(hrefRegex);
 
   // repalce all of URLs while ignoring URLs that are already within an <a>, <img> or <audio> tag.
   const convertedText = text.replace(urlRegex, (url) => {
     if (hrefs && hrefs.includes(`<a href="${url}"`))
       return url;
+    else if (youtubeRegex.test(url))
+      return `<span class="youtube-url" data-src="${url}"></span>`;
     else if (imageRegex.test(url))
       return `<img src="${url}" alt="${url}" class="ql-editor-image"/>`;
     else


### PR DESCRIPTION
## Introduction
This PR adds support for rendering external image links and YouTube video embeds.

## Changes
- **convertUrlsToLinks**:
  - Moved regex patterns to `constants.ts`.
  - Updated `convertUrlsToLinks` to handle external image URLs and YouTube video URLs.
  - External image URLs are converted to `<img>` tags with appropriate class and attributes.
  - YouTube video URLs are converted to `<span>` tags with a placeholder class for later rendering.


- **parseOptions**:
  - Render external image links as `<img>` tags with appropriate class and attributes.
  - Render YouTube video URLs using the new `ExternalEmbed` component.

- **ExternalEmbed**:
  - New component to handle YouTube video embedding.
  - Designed to be extendable for other video services in the future.
## Impact
- Users can now include external image links and YouTube videos in their posts.
- Existing functionality for uploaded images remains unaffected.

## Example
- Embedded YouTube video: [Local Preview](http://localhost:3000/#/post/dceec781-723a-4251-a701-72ef46c11525)

